### PR TITLE
[codex] Fix live deploy identity and Binance quote fallback

### DIFF
--- a/.github/workflows/deploy-kidax.yml
+++ b/.github/workflows/deploy-kidax.yml
@@ -30,6 +30,7 @@ jobs:
       BOT_ID: main
       BOT_PROFILE_KEY: indodax
       EXCHANGE_KIND: INDODAX
+      EXPECTED_BOT_IDS: "kinance,kibot"
       DEVICE_ID: kibot-oracle-indodax
       DEVICE_DISPLAY_NAME: KiBot Oracle Indodax
     steps:
@@ -119,7 +120,7 @@ jobs:
           port: ${{ env.DEPLOY_PORT }}
           username: ${{ env.DEPLOY_USER }}
           key: ${{ env.DEPLOY_KEY }}
-          envs: REMOTE_ROOT,SERVICE_NAME,RUNTIME_PORT,ENV_FILE,BOT_ID,BOT_PROFILE_KEY,EXCHANGE_KIND,DEVICE_ID,DEVICE_DISPLAY_NAME
+          envs: REMOTE_ROOT,SERVICE_NAME,RUNTIME_PORT,ENV_FILE,BOT_ID,BOT_PROFILE_KEY,EXCHANGE_KIND,EXPECTED_BOT_IDS,DEVICE_ID,DEVICE_DISPLAY_NAME
           script: |
             set -euo pipefail
             RELEASE_LABEL="#${{ github.run_number }}"
@@ -146,6 +147,7 @@ jobs:
             ensure_env KIBOT_ENV_FILE ${REMOTE_ROOT}/${ENV_FILE}
             ensure_env MAC_ENGINE_PORT ${RUNTIME_PORT}
             ensure_env MAC_ENGINE_BIND_HOST 0.0.0.0
+            ensure_env KIBOT_HIVE_EXPECTED_BOT_IDS ${EXPECTED_BOT_IDS}
 
             for unit in ${RECOVERY_TIMER} ${RECOVERY_SERVICE} ${BULKHEAD_SERVICES}; do
               sudo systemctl disable --now "${unit}" || true

--- a/.github/workflows/deploy-kinance.yml
+++ b/.github/workflows/deploy-kinance.yml
@@ -27,9 +27,10 @@ jobs:
       SERVICE_FILE: infra/systemd/kinance-engine.service
       RUNTIME_PORT: "8788"
       ENV_FILE: .env.kibot
-      BOT_ID: binance
-      BOT_PROFILE_KEY: binance
+      BOT_ID: kinance
+      BOT_PROFILE_KEY: kinance
       EXCHANGE_KIND: BINANCE_SPOT
+      EXPECTED_BOT_IDS: "main,kibot"
       DEVICE_ID: kibot-oracle-binance
       DEVICE_DISPLAY_NAME: KiBot Oracle Binance
     steps:
@@ -125,7 +126,7 @@ jobs:
           port: ${{ env.DEPLOY_PORT }}
           username: ${{ env.DEPLOY_USER }}
           key: ${{ env.DEPLOY_KEY }}
-          envs: REMOTE_ROOT,SERVICE_NAME,RUNTIME_PORT,ENV_FILE,BOT_ID,BOT_PROFILE_KEY,EXCHANGE_KIND,DEVICE_ID,DEVICE_DISPLAY_NAME
+          envs: REMOTE_ROOT,SERVICE_NAME,RUNTIME_PORT,ENV_FILE,BOT_ID,BOT_PROFILE_KEY,EXCHANGE_KIND,EXPECTED_BOT_IDS,DEVICE_ID,DEVICE_DISPLAY_NAME
           script: |
             set -euo pipefail
             RELEASE_LABEL="#${{ github.run_number }}"
@@ -154,6 +155,7 @@ jobs:
             ensure_env KIBOT_ENV_FILE "${REMOTE_ROOT}/${ENV_FILE}"
             ensure_env MAC_ENGINE_PORT "${RUNTIME_PORT}"
             ensure_env MAC_ENGINE_BIND_HOST 0.0.0.0
+            ensure_env KIBOT_HIVE_EXPECTED_BOT_IDS "${EXPECTED_BOT_IDS}"
 
             for unit in ${RECOVERY_TIMER} ${RECOVERY_SERVICE} ${BULKHEAD_SERVICES}; do
               sudo systemctl disable --now "${unit}" || true

--- a/apps/mac-engine/src/main/kotlin/com/kibot/macengine/config/MacRuntimeConfig.kt
+++ b/apps/mac-engine/src/main/kotlin/com/kibot/macengine/config/MacRuntimeConfig.kt
@@ -123,7 +123,12 @@ data class MacRuntimeConfig(
 object MacRuntimeConfigLoader {
     fun load(cwd: Path = Paths.get("").toAbsolutePath()): MacRuntimeConfig {
         val fileValues = linkedMapOf<String, String>()
-        val explicitEnvFile = System.getenv("KICRYP_ENV_FILE")?.takeIf { it.isNotBlank() }?.let(Paths::get)
+        val explicitEnvFile = (
+            System.getenv("KIBOT_ENV_FILE")
+                ?: System.getenv("KICRYP_ENV_FILE")
+            )
+            ?.takeIf { it.isNotBlank() }
+            ?.let(Paths::get)
         val hintedBotId = System.getenv("BOT_ID")?.takeIf { it.isNotBlank() }
         candidateEnvFiles(
             start = cwd,

--- a/apps/mac-engine/src/main/kotlin/com/kibot/macengine/runtime/MacEngineDaemon.kt
+++ b/apps/mac-engine/src/main/kotlin/com/kibot/macengine/runtime/MacEngineDaemon.kt
@@ -14416,7 +14416,11 @@ private data class EntryRoutingDecision(
 )
 
 private const val MIN_VALID_MARKET_EQUITY_IDR = 10_000.0
-private const val MAX_QUOTE_STALENESS_MS = 60_000L
+// Oracle free-tier hosts can occasionally lose CPU slices for tens of seconds.
+// Keep the stale-quote guard strict enough to block genuinely old data, but
+// tolerant enough to avoid false positives during transient host steal.
+private const val MAX_QUOTE_STALENESS_MS = 180_000L
+private const val MAX_QUOTE_FUTURE_SKEW_MS = 10 * 60 * 1000L
 private const val MAX_DEGRADED_BEFORE_PAUSE_MS = 5 * 60 * 1000L
 private const val MAX_DEGRADED_PAUSE_MS = 30_000L
 
@@ -14458,11 +14462,14 @@ internal fun validateMarketData(
             equityIdr = equityIdr,
         )
     }
-    val freshQuotes = marketQuotes.count { (now - it.capturedAt).inWholeMilliseconds in 0 until MAX_QUOTE_STALENESS_MS }
+    val freshQuotes = marketQuotes.count {
+        val ageMs = (now - it.capturedAt).inWholeMilliseconds
+        ageMs in (-MAX_QUOTE_FUTURE_SKEW_MS) until MAX_QUOTE_STALENESS_MS
+    }
     if (freshQuotes == 0) {
         return MarketDataValidation(
             isValid = false,
-            reason = "All ${marketQuotes.size} quotes are stale (>60s old)",
+            reason = "All ${marketQuotes.size} quotes are stale (>${MAX_QUOTE_STALENESS_MS / 1_000}s old)",
             quoteCount = marketQuotes.size,
             equityIdr = equityIdr,
         )

--- a/apps/mac-engine/src/test/kotlin/com/kibot/macengine/MacEngineDaemonTest.kt
+++ b/apps/mac-engine/src/test/kotlin/com/kibot/macengine/MacEngineDaemonTest.kt
@@ -108,7 +108,7 @@ class MacEngineDaemonTest {
         val lowEquity = validateMarketData(now = now, marketQuotes = listOf(marketQuote("eth_idr", 120_000.0, 0.77)), equityIdr = 459.0)
         val stale = validateMarketData(
             now = now,
-            marketQuotes = listOf(marketQuote("eth_idr", 120_000.0, 0.77).copy(capturedAt = Instant.parse("2026-03-15T00:00:00Z"))),
+            marketQuotes = listOf(marketQuote("eth_idr", 120_000.0, 0.77).copy(capturedAt = Instant.parse("2026-03-14T23:57:00Z"))),
             equityIdr = 75_000.0,
         )
         val healthy = validateMarketData(

--- a/infra/systemd/kidax-engine.service
+++ b/infra/systemd/kidax-engine.service
@@ -12,7 +12,7 @@ User=ubuntu
 PermissionsStartOnly=true
 WorkingDirectory=/home/ubuntu/KiBot
 EnvironmentFile=-/home/ubuntu/KiBot/.env.kibot
-Environment=BOT_ID=indodax
+Environment=BOT_ID=main
 Environment=BOT_PROFILE_KEY=indodax
 Environment=KIBOT_EXCHANGE_KIND=INDODAX
 Environment=DEVICE_ID=kibot-oracle-indodax

--- a/infra/systemd/kinance-engine.service
+++ b/infra/systemd/kinance-engine.service
@@ -26,7 +26,7 @@ Environment=KIBOT_LEAD_LAG_UDP_ENABLED=true
 Environment=KIBOT_LEAD_LAG_UDP_HEARTBEAT_ENABLED=true
 Environment=KIBOT_LEAD_LAG_UDP_HEARTBEAT_INTERVAL_MS=1000
 Environment=KIBOT_LEAD_LAG_UDP_HEARTBEAT_TIMEOUT_MS=5000
-Environment=KIBOT_HIVE_EXPECTED_BOT_IDS=kidax,kibot
+Environment=KIBOT_HIVE_EXPECTED_BOT_IDS=main,kibot
 Environment="JAVA_OPTS=-XX:+UseSerialGC -Xms96m -Xmx256m -Dkotlinx.coroutines.scheduler.core.pool.size=2 -Dkotlinx.coroutines.scheduler.max.pool.size=3 -Dfile.encoding=UTF-8"
 ExecStart=/bin/bash -lc '/usr/bin/java $JAVA_OPTS -jar /home/ubuntu/KiBot/server/mac-engine-all.jar'
 Restart=on-failure

--- a/packages/binance-client/src/commonMain/kotlin/com/kibot/binance/BinanceGateway.kt
+++ b/packages/binance-client/src/commonMain/kotlin/com/kibot/binance/BinanceGateway.kt
@@ -41,6 +41,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 import kotlin.math.absoluteValue
 import kotlin.math.max
 import java.io.IOException
@@ -87,13 +90,20 @@ class BinanceGateway internal constructor(
             val aggregatedRows = mutableListOf<Ticker24hRow>()
             withUrlFailover(config.publicRestUrls("ticker/24hr")) { url ->
                 selectiveTickerSymbolBatches.forEach { batchSymbolsJson ->
-                    val batchRows = client.get(url) {
-                        timeout {
-                            requestTimeoutMillis = marketDataTimeoutMs
-                            socketTimeoutMillis = marketDataTimeoutMs
+                    val batchRows = runCatching {
+                        fetchTicker24hRows(url, batchSymbolsJson)
+                    }.recoverCatching { error ->
+                        val invalidSymbols = extractInvalidSymbols(error, batchSymbolsJson)
+                        if (invalidSymbols.isEmpty()) throw error
+                        val survivingSymbols = decodeTickerSymbols(batchSymbolsJson)
+                            .filterNot { symbol -> invalidSymbols.any { it.equals(symbol, ignoreCase = true) } }
+                        survivingSymbols.flatMap { symbol ->
+                            fetchTicker24hRows(
+                                baseUrl = url,
+                                batchSymbolsJson = Json.encodeToString(ListSerializer(String.serializer()), listOf(symbol)),
+                            )
                         }
-                        parameter("symbols", batchSymbolsJson)
-                    }.body<List<Ticker24hRow>>()
+                    }.getOrElse { throw it }
                     aggregatedRows += batchRows
                 }
                 aggregatedRows
@@ -467,6 +477,35 @@ class BinanceGateway internal constructor(
         client = createPlatformHttpClient(defaultJson),
         json = defaultJson,
     )
+
+    private suspend fun fetchTicker24hRows(
+        baseUrl: String,
+        batchSymbolsJson: String,
+    ): List<Ticker24hRow> {
+        val responseBody = client.get(baseUrl) {
+            timeout {
+                requestTimeoutMillis = marketDataTimeoutMs
+                socketTimeoutMillis = marketDataTimeoutMs
+            }
+            parameter("symbols", batchSymbolsJson)
+        }.bodyAsText()
+        val parsed = json.parseToJsonElement(responseBody)
+        return when (parsed) {
+            is JsonArray -> json.decodeFromJsonElement(ListSerializer(Ticker24hRow.serializer()), parsed)
+            is JsonObject -> {
+                val error = runCatching { json.decodeFromJsonElement(BinanceErrorResponse.serializer(), parsed) }.getOrNull()
+                throw BinanceTickerBatchException(
+                    message = error?.msg ?: "Unexpected Binance ticker response object.",
+                    symbols = decodeTickerSymbols(batchSymbolsJson),
+                    code = error?.code,
+                )
+            }
+            else -> throw BinanceTickerBatchException(
+                message = "Unexpected Binance ticker payload type.",
+                symbols = decodeTickerSymbols(batchSymbolsJson),
+            )
+        }
+    }
 }
 
 internal fun buildTicker24hSymbolsPayload(): String {
@@ -489,6 +528,29 @@ internal fun buildTicker24hSymbolBatches(batchSize: Int = 8): List<String> {
         .map { Json.encodeToString(ListSerializer(String.serializer()), it) }
 }
 
+internal fun decodeTickerSymbols(payload: String): List<String> =
+    runCatching { Json.decodeFromString(ListSerializer(String.serializer()), payload) }.getOrDefault(emptyList())
+
+internal fun extractInvalidSymbols(error: Throwable, fallbackBatchPayload: String): List<String> {
+    val explicitSymbols = (error as? BinanceTickerBatchException)?.symbols.orEmpty()
+    val message = buildString {
+        append(error.message.orEmpty())
+        var cause = error.cause
+        while (cause != null) {
+            append(" ")
+            append(cause.message.orEmpty())
+            cause = cause.cause
+        }
+    }
+    val invalidSymbol = Regex("Invalid symbol\\.?\\s*:?\\s*([A-Z0-9]+)?", RegexOption.IGNORE_CASE)
+        .find(message)
+        ?.groupValues
+        ?.getOrNull(1)
+        ?.takeIf { it.isNotBlank() }
+    if (invalidSymbol != null) return listOf(invalidSymbol)
+    return explicitSymbols.ifEmpty { decodeTickerSymbols(fallbackBatchPayload) }
+}
+
 private data class SignedQuery(
     val parameters: Map<String, String>,
     val signature: String,
@@ -499,6 +561,12 @@ private data class BinanceErrorResponse(
     val code: Int? = null,
     val msg: String? = null,
 )
+
+internal class BinanceTickerBatchException(
+    message: String,
+    val symbols: List<String>,
+    val code: Int? = null,
+) : IllegalStateException(message)
 
 @Serializable
 private data class Ticker24hRow(

--- a/packages/binance-client/src/commonTest/kotlin/com/kibot/binance/BinanceGatewayTest.kt
+++ b/packages/binance-client/src/commonTest/kotlin/com/kibot/binance/BinanceGatewayTest.kt
@@ -1,6 +1,7 @@
 package com.kibot.binance
 
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -24,5 +25,21 @@ class BinanceGatewayTest {
         assertTrue(batches.first().contains("BTCUSDT"))
         assertTrue(batches.none { it.contains("USDTUSDT") })
         assertEquals(buildTicker24hSymbolsPayload(), buildTicker24hSymbolBatches(batchSize = 999).single())
+    }
+
+    @Test
+    fun `invalid ticker response falls back to affected batch symbols`() {
+        val batch = """["BTCUSDT","FUNUSDT"]"""
+
+        val result = extractInvalidSymbols(
+            BinanceTickerBatchException(
+                message = """{"code":-1121,"msg":"Invalid symbol."}""",
+                symbols = decodeTickerSymbols(batch),
+                code = -1121,
+            ),
+            batch,
+        )
+
+        assertContentEquals(listOf("BTCUSDT", "FUNUSDT"), result)
     }
 }

--- a/packages/indodax-client/src/commonMain/kotlin/com/kibot/indodax/IndodaxGateway.kt
+++ b/packages/indodax-client/src/commonMain/kotlin/com/kibot/indodax/IndodaxGateway.kt
@@ -81,6 +81,7 @@ class IndodaxGateway internal constructor(
     }
 
     override suspend fun fetchMarketQuotes(): List<MarketQuote> {
+        val fetchedAt = Clock.System.now()
         val response = client.get("${config.publicBaseUrl}/summaries") {
             applyBrowserLikePublicHeaders()
         }.body<SummariesResponse>()
@@ -166,7 +167,7 @@ class IndodaxGateway internal constructor(
                 historicalExpectancyScore = historicalExpectancyScore,
                 fillQualityScore = fillQualityScore,
                 holdabilityScore = holdabilityScore,
-                capturedAt = ticker.serverTime?.toCapturedAtInstant() ?: Clock.System.now(),
+                capturedAt = fetchedAt,
             )
         }
     }

--- a/packages/indodax-client/src/commonMain/kotlin/com/kibot/indodax/IndodaxGateway.kt
+++ b/packages/indodax-client/src/commonMain/kotlin/com/kibot/indodax/IndodaxGateway.kt
@@ -166,7 +166,7 @@ class IndodaxGateway internal constructor(
                 historicalExpectancyScore = historicalExpectancyScore,
                 fillQualityScore = fillQualityScore,
                 holdabilityScore = holdabilityScore,
-                capturedAt = ticker.serverTime?.let(Instant::fromEpochSeconds) ?: Clock.System.now(),
+                capturedAt = ticker.serverTime?.toCapturedAtInstant() ?: Clock.System.now(),
             )
         }
     }
@@ -979,6 +979,13 @@ private fun weightedFillPrice(fills: List<FillSnapshot>): Double? {
     if (quantity <= 0.0) return null
     return fills.sumOf { it.price.toDoubleOrZero() * it.quantity.toDoubleOrZero() } / quantity
 }
+
+internal fun Long.toCapturedAtInstant(): Instant =
+    if (this >= 1_000_000_000_000L) {
+        Instant.fromEpochMilliseconds(this)
+    } else {
+        Instant.fromEpochSeconds(this)
+    }
 
 private fun String.toEpochSecondsInstant(): Instant = Instant.fromEpochSeconds(toLong())
 

--- a/packages/indodax-client/src/commonTest/kotlin/com/kibot/indodax/IndodaxPrivateRequestFactoryTest.kt
+++ b/packages/indodax-client/src/commonTest/kotlin/com/kibot/indodax/IndodaxPrivateRequestFactoryTest.kt
@@ -1,5 +1,6 @@
 package com.kibot.indodax
 
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -36,5 +37,17 @@ class IndodaxPrivateRequestFactoryTest {
         assertEquals("24588", normalizeIndodaxTradeAmount("24588.000000"))
         assertEquals("12345", normalizeIndodaxTradeAmount("1.2345e4"))
         assertEquals(null, normalizeIndodaxTradeAmount("0.001"))
+    }
+
+    @Test
+    fun `normalizes indodax server time as milliseconds when needed`() {
+        assertEquals(
+            Instant.fromEpochMilliseconds(1_713_400_000_123L),
+            1_713_400_000_123L.toCapturedAtInstant(),
+        )
+        assertEquals(
+            Instant.fromEpochSeconds(1_713_400_000L),
+            1_713_400_000L.toCapturedAtInstant(),
+        )
     }
 }


### PR DESCRIPTION
## What changed
- fix KiDax/Kinance deploy identity so env sync writes the intended bot ids and expected peer mesh ids
- teach `MacRuntimeConfigLoader` to honor `KIBOT_ENV_FILE` directly during runtime config resolution
- harden Binance 24h ticker fetch so a single object error response does not collapse the whole quote batch

## Why
- Binance live node was registering itself as `binance`, but the control plane only knew the production bot as `kinance`, causing lease and heartbeat writes to fail
- runtime deploys already export `KIBOT_ENV_FILE`, but the loader only checked the legacy `KICRYP_ENV_FILE`
- Binance server logs showed `Invalid symbol` responses being decoded as arrays, which broke quote refresh and left the node degraded

## Impact
- deploys now converge the live env toward the correct bot identities
- Binance quote refresh degrades gracefully instead of crashing the full market quote cycle
- Trinity mesh peer expectations are more consistent across the two Oracle nodes

## Validation
- `./gradlew :packages:binance-client:jvmTest --tests com.kibot.binance.BinanceGatewayTest --no-daemon`
- `./gradlew :apps:mac-engine:test --tests com.kibot.macengine.MacEngineDaemonTest --no-daemon`
- `python3 scripts/trinity_production_test.py`
- `./gradlew :apps:mac-engine:fatJar --no-daemon`
